### PR TITLE
SCRUM-13: Improve downloaded data naming and saving

### DIFF
--- a/sports_api/data_scraper.py
+++ b/sports_api/data_scraper.py
@@ -1,10 +1,9 @@
-import json
-import os
 from time import sleep
-from typing import Any, Dict, Callable, Optional
+from typing import Any, Callable
 
-from sports_api.config import Config
 from sports_api import ApiClient
+from sports_api.config import Config
+from sports_api.utils.datascraper_utils import generate_file_path
 from sports_api.utils.file_utils import save_json_file
 
 
@@ -17,8 +16,11 @@ class DataScraper:
         self.config = config
         self.api_client = api_client or (ApiClient(config) if config else None)
 
-    def scrape_data(self, scraper_func: Callable, save_data: bool = False,
-                    output_path: str = None, output_file: str = None, **kwargs) -> Any:
+        if not self.api_client:
+            raise ValueError("Either valid config or api_client must be provided.")
+
+    def scrape_data(self, scraper_func: Callable, save_data: bool = False, output_path: str = None,
+                    output_file: str = None, data_type: str = None, **kwargs) -> Any:
         """
         Generic method to scrape data using the provided scraper function.
 
@@ -26,20 +28,29 @@ class DataScraper:
         :param save_data: Whether to save the data to disk
         :param output_path: Optional override for output path
         :param output_file: Optional override for output filename
+        :param data_type: Type of data for automatic file naming
         :param kwargs: Additional arguments to pass to the scraper function
         :return: The scraped data
         """
         data = scraper_func(**kwargs)
 
-        if data and save_data and self.config:
-            storage_config = self.config.get_output_settings()
-            final_path = output_path or storage_config['output_path']
-            final_file = output_file or storage_config['default_file']
+        if data and save_data:
+            # If output_path or output_file are not provided, generate them
+            if data_type and not (output_path and output_file):
+                generated_path, generated_file = generate_file_path(self.config, data_type, **kwargs)
+                final_path = output_path or generated_path
+                final_file = output_file or generated_file
+            else:
+                storage_config = self.config.get_output_settings()
+                final_path = output_path or storage_config['output_path']
+                final_file = output_file or storage_config['default_file']
+
             save_json_file(data, final_path, final_file)
 
         return data
 
-    def _retrieve_all_rounds(self, league_id: int, season: str, start_round: int, end_round: int) -> list[Any]:
+    def _retrieve_all_rounds(self, league_id: int, season: str, start_round: int, end_round: int,
+                             save_individual_rounds: bool = False) -> list[Any]:
         """
         Retrieve data for all rounds in the specified range.
 
@@ -47,6 +58,7 @@ class DataScraper:
         :param season: Season (e.g. '2024-2025')
         :param start_round: Number of the first round to retrieve
         :param end_round: Number of the last round to retrieve (inclusive)
+        :param save_individual_rounds: Whether to save each round to a separate file
         :return: List of all matches from the specified rounds
         """
         all_rounds_data = []
@@ -60,6 +72,16 @@ class DataScraper:
                     matches = round_data['events']
                     all_rounds_data.extend(matches)
                     print(f'Round {round_num}: retrieved {len(matches)} matches.')
+
+                    if save_individual_rounds:
+                        round_dir, round_file = generate_file_path(
+                            config=self.config,
+                            data_type="rounds",
+                            league_id=league_id,
+                            season=season,
+                            round_num=round_num
+                        )
+                        save_json_file(matches, round_dir, round_file)
                 else:
                     print(f'Round {round_num}: no data was found.')
             except Exception as e:
@@ -70,7 +92,8 @@ class DataScraper:
         return all_rounds_data
 
     def scrape_all_rounds(self, league_id: int, season: str, start_round: int = 1, end_round: int = 38,
-                          output_path: str = None, output_file: str = None, save_data: bool = False) -> list[Any]:
+                          output_path: str = None, output_file: str = None, save_all_rounds: bool = False,
+                          save_individual_rounds: bool = False) -> list[Any]:
         """
         Scrape data for consecutive rounds for the specified season and league.
 
@@ -80,18 +103,21 @@ class DataScraper:
         :param end_round: Number of the last round to retrieve (inclusive)
         :param output_path: Optional override for output path from config
         :param output_file: Optional override for output filename from config
-        :param save_data: Whether the data is to be saved to disk
+        :param save_all_rounds: Whether to save the data to disk into a single file
+        :param save_individual_rounds: Whether to save each round to a separate file
         :return: List of round data
         """
         return self.scrape_data(
             scraper_func=self._retrieve_all_rounds,
-            save_data=save_data,
+            save_data=save_all_rounds,
             output_path=output_path,
             output_file=output_file,
+            data_type="rounds",
             league_id=league_id,
             season=season,
             start_round=start_round,
-            end_round=end_round
+            end_round=end_round,
+            save_individual_rounds=save_individual_rounds
         )
 
     def scrape_league_table(self, league_id: int, season: str, output_path: str = None, output_file: str = None,
@@ -111,6 +137,7 @@ class DataScraper:
             save_data=save_data,
             output_path=output_path,
             output_file=output_file,
+            data_type="league_table",
             league_id=league_id,
             season=season
         )

--- a/sports_api/utils/datascraper_utils.py
+++ b/sports_api/utils/datascraper_utils.py
@@ -1,0 +1,67 @@
+import os
+
+from sports_api.config import Config
+
+
+def league_id_to_name(league_id: int) -> str:
+    """
+    Map league IDs to their names for file naming purposes.
+    """
+    league_mapping = {
+        4328: "premier_league",
+        4331: "bundesliga",
+        4332: "serie_a",
+        4334: "ligue_1",
+        4335: "laliga",
+        # Add more leagues as needed
+    }
+    return league_mapping.get(league_id, f"league_{league_id}")
+
+
+def generate_file_path(config: Config, data_type: str, league_id: int = None, season: str = None, round_num: int = None,
+                       **kwargs) -> tuple[str, str]:
+    """
+    Generate appropriate file path and name based on the data type and parameters.
+
+    :param config: Config object
+    :param data_type: Type of data (e.g., 'rounds', 'league_table')
+    :param league_id: Optional league ID
+    :param season: Optional season string (e.g., '2024-2025')
+    :param round_num: Optional round number
+    :param kwargs: Additional parameters for specialized naming
+    :return: Tuple of (directory_path, filename)
+    """
+    if not config:
+        raise ValueError("Config object is required to generate file path.")
+
+    base_path = config.get_output_settings()['output_path']
+
+    # Get league name from ID or use the ID as string
+    league_name = league_id_to_name(league_id) if league_id else ""
+
+    # Format season for filenames (2024-2025 -> 2024_2025)
+    formatted_season = season.replace("-", "_") if season else ""
+
+    if data_type == "rounds":
+        directory = os.path.join(base_path, "rounds", league_name, formatted_season)
+
+        if round_num is None:
+            # Multiple rounds
+            start_round = kwargs.get('start_round', 1)
+            end_round = kwargs.get('end_round', 38)
+            filename = f"{league_name}_{formatted_season}_rounds_{start_round}_to_{end_round}.json"
+        else:
+            # Single round
+            filename = f"{league_name}_{formatted_season}_round_{round_num}.json"
+
+    elif data_type == "league_table":
+        # For league table data
+        directory = os.path.join(base_path, "tables", league_name, formatted_season)
+        filename = f"{league_name}_{formatted_season}_table.json"
+
+    else:
+        # Default case
+        directory = os.path.join(base_path, data_type)
+        filename = f"{data_type}_{league_name}_{formatted_season}.json"
+
+    return directory, filename


### PR DESCRIPTION
1. You can now save individual round data by setting **save_individual_rounds=True**.
2. Each round will be saved in its own file (e.g., **laliga_2024_2025_round_1.json**).
3. You can save the combined data by setting **save_data=True**.
4. The directory structure remains organized by league, season and data type, e.g:  
- /retrieved_data/rounds/2024_2025/laliga/laliga_2024_2025_round_1.json
- /retrieved_data/rounds/laliga/2024_2025/laliga_2024_2025_round_2.json
- ...
- /retrieved_data/rounds/laliga/2024_2025/laliga_2024_2025_round_5.json
- /retrieved_data/rounds/laliga/2024_2025/laliga_2024_2025_rounds_1_to_5.json