### PR TITLE
Feature/1.7.0/scheduler

### DIFF
--- a/scheduler.py
+++ b/scheduler.py
@@ -1,0 +1,45 @@
+import datetime
+
+import schedule
+from sports_api.config import Config
+from sports_api.data_scraper import DataScraper
+
+
+def job_scrape_league_table():
+    print(f"Starting job at {datetime.datetime.now()}...")
+    print("Scraping league table...")
+    config = Config()
+    scraper = DataScraper(config)
+    scraper.scrape_league_table(
+        league_id=4335,  # Spanish La Liga
+        season='2024-2025',
+        save_data=True,
+    )
+    print(f"Finished job at {datetime.datetime.now()}.", end="\n\n\n")
+
+
+def job_scrape_all_rounds():
+    print(f"Starting job at {datetime.datetime.now()}...")
+    print("Scraping all rounds...")
+    config = Config()
+    scraper = DataScraper(config)
+    scraper.scrape_all_rounds(
+        league_id=4335,  # Spanish La Liga
+        season='2024-2025',
+        start_round=1,
+        save_all_rounds=True,
+        save_individual_rounds=True,
+    )
+    print(f"Finished job at {datetime.datetime.now()}.", end="\n\n\n")
+
+
+def main():
+    schedule.every().sunday.at("23:30").do(job_scrape_league_table)
+    schedule.every().sunday.at("23:30").do(job_scrape_all_rounds)
+
+    while True:
+        schedule.run_pending()
+
+
+if __name__ == '__main__':
+    main()

--- a/sports_api/data_scraper.py
+++ b/sports_api/data_scraper.py
@@ -111,8 +111,8 @@ class DataScraper:
         return self.scrape_data(
             scraper_func=self._retrieve_all_rounds,
             save_data=save_all_rounds,
-            output_path=output_path,
-            output_file=output_file,
+            # output_path=output_path,
+            # output_file=output_file,
             data_type="rounds",
             league_id=league_id,
             season=season,
@@ -136,8 +136,8 @@ class DataScraper:
         return self.scrape_data(
             scraper_func=self.api_client.get_league_table,
             save_data=save_data,
-            output_path=output_path,
-            output_file=output_file,
+            # output_path=output_path,
+            # output_file=output_file,
             data_type="league_table",
             league_id=league_id,
             season=season


### PR DESCRIPTION
Commented **_output_path_** and **_output_path_** out. Right now all kwargs are passed to the scraper function. **_scrape_league_table_** and **_scrape_all_round_** don’t accept output parameters, as they are meant only for the storage component.

Added simple scheduler for **_scrape_league_table_** and **_scrape_all_rounds_**. Both jobs should be run once per week.